### PR TITLE
Add AS212238

### DIFF
--- a/input/datacenter/ASN.txt
+++ b/input/datacenter/ASN.txt
@@ -787,3 +787,4 @@ AS16652 # Riseup Networks www.ipqualityscore.com/asn-details/AS16652/riseup-netw
 AS9009 # M247 Europe SRL
 AS42675 # https://obe.net/hosting
 AS329184 # Host Africa (Pty) Ltd https://ipinfo.io/AS329184
+AS212238 # CDNEXT, GB


### PR DESCRIPTION
AS212238 / CDNEXT belongs to DataCamp Limited, as the already listed AS60068 / CDN77. IP-addresses from this ASN are often used by VPN providers.