### PR TITLE
Remove non-datacenter ASN's

### DIFF
--- a/input/datacenter/ASN.txt
+++ b/input/datacenter/ASN.txt
@@ -841,13 +841,10 @@ AS48282 # VDSINA
 AS31898 # Oracle cloud
 AS58065 # Fiber Grid/PacketExchange
 AS137409 # Global Secure Layer Data Center
-AS203214 # Hulum Data Center
-AS46023 # Quantum Tera Network
 AS52468 # UFINET 
 AS265620 # UFINET
 AS200350 # Yandex
 AS208795 # Yandex
-AS208932 # Teleglobal
 AS197155 # Artnet
 AS200088 # Artnet
 AS53667 # FranTech Solutions


### PR DESCRIPTION
I wrote a program to compare this repository with the much larger list at https://github.com/Munzy/blackbox

Here were the only empty ASN's in this repository, which are naturally missing from that list:
- [ ] 17920
- [ ] 38279
- [ ] 58667

Here were the only non-empty ASN's in this repository but missing from that list:
- [x] 46023 ISP
- [x] 203214 ISP
- [x] 208932 Consruction
- [ ] 265620 ISP + Datacenter (ambiguous)

**This PR removes the _checked_ items**