### PR TITLE
feat: Add workflow for apple-privacy-relay vpn-ips

### DIFF
--- a/.github/workflows/fetch-apple-privacy-relay.yml
+++ b/.github/workflows/fetch-apple-privacy-relay.yml
@@ -1,0 +1,53 @@
+---
+
+name: "Fetch: Apple Privacy-Relay"
+on:
+  push:
+    paths:
+    - '.github/workflows/fetch-apple-privacy-relay.yml'
+  schedule:
+    - cron:  '30 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  build_and_commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download and process
+      run: |
+        curl -s https://mask-api.icloud.com/egress-ip-ranges.csv | tail -n +2 | cut -d ',' -f1 | sort | uniq > /tmp/apple.txt
+    - name: Merge Lists
+      run: |
+        perl ./helpers/cleanup.pl /tmp/apple.txt > apple.txt
+    - name: Test generated Lists
+      run: |
+        if [[ $(grep ^0. apple.txt | wc -l) != "0" ]]; then
+          echo "Lists can not contain 0.0.0.0/8"
+          exit 1
+        fi
+        if [[ $(grep ^127. apple.txt| wc -l) != "0" ]]; then
+          echo "Lists can not contain 127.0.0.1/8"
+          exit 1
+        fi
+
+        ips_covered=$(awk -F/ 'BEGIN{a=0}{if($2==""){a+=1}else{a+=2^(32-$2)}}END{print a}' apple.txt)
+        if [[ "$ips_covered" -lt 500 ]]; then
+          echo "Too few addresses covered ($ips_covered)"
+          exit 1
+        fi
+        if [[ "$ips_covered" -gt 2000 ]]; then
+          echo "Too many addresses covered ($ips_covered)"
+          exit 1
+        fi
+    - name: Push Output of apple.txt
+      uses: X4BNet/copy_file_to_another_repo_action@main
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.MY_GITHUB_TOKEN }}
+      with:
+        source_file: 'apple.txt'
+        destination_repo: '${{ github.repository }}'
+        destination_folder: '/input/vpn/ips/'
+        user_email: 'automated@x4b.net'
+        user_name: 'listbuilder'
+        destination_branch: "main"


### PR DESCRIPTION
As mentioned in https://github.com/X4BNet/lists_vpn/issues/203 => Apple provides a list of IPs that are used for their VPN-Service