### PR TITLE
fix: Add mullvad IPv6 addresses

### DIFF
--- a/.github/workflows/fetch-mullvadvpn.yml
+++ b/.github/workflows/fetch-mullvadvpn.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Download and process
       run: |
         curl -s https://api.mullvad.net/www/relays/all | jq -r '.[] | .ipv4_addr_in' | sort -n | uniq > /tmp/mullvadvpn.txt
+        curl -s https://api.mullvad.net/www/relays/all | jq -r '.[] | .ipv6_addr_in' | sort -n | uniq >> /tmp/mullvadvpn.txt
     - name: Merge Lists
       run: |
         perl ./helpers/cleanup.pl /tmp/mullvadvpn.txt > mullvadvpn.txt


### PR DESCRIPTION
As the mullvad API also provides IPv6 addresses - we should add them as the information would be wasted otherwise.